### PR TITLE
Fix missing throw statement to build with Java 8

### DIFF
--- a/src/lib/patch/http/LaxHttpURLConnection.java
+++ b/src/lib/patch/http/LaxHttpURLConnection.java
@@ -10,15 +10,15 @@ import java.net.*;
 
 public class LaxHttpURLConnection extends sun.net.www.protocol.http.HttpURLConnection {
 
-	public LaxHttpURLConnection(URL u, String host, int port) {
+	public LaxHttpURLConnection(URL u, String host, int port) throws IOException {
 		super(u, new Proxy(Proxy.Type.HTTP, InetSocketAddress.createUnresolved(host, port)));
     	}
 
-    	public LaxHttpURLConnection(URL u, Proxy p) {
+    	public LaxHttpURLConnection(URL u, Proxy p) throws IOException {
 		super(u, p, new Handler());
     	}
 
-    	public LaxHttpURLConnection(URL u) {
+    	public LaxHttpURLConnection(URL u) throws IOException {
 		super(u, null, new Handler());
     	}
 


### PR DESCRIPTION
I like jimmix but it won't compile on Java 8 because its compiler has stricter checks on missing throw statements. Here is a quick fix, if you would like to merge it.